### PR TITLE
fix(parser): tokenize unclosed triple quote with content correctly

### DIFF
--- a/pkg/parser/lexer.go
+++ b/pkg/parser/lexer.go
@@ -448,22 +448,26 @@ func (l *Lexer) skipSpaces() {
 		case unicode.IsSpace(r):
 			l.skipN(size)
 		case r == '#' || r == '/' && l.peekIs(1, '/') || r == '-' && l.peekIs(1, '-'):
-			l.skipComment("\n")
+			l.skipComment("\n", false)
 		case r == '/' && l.peekIs(1, '*'):
-			l.skipComment("*/")
+			l.skipComment("*/", true)
 		default:
 			return
 		}
 	}
 }
 
-func (l *Lexer) skipComment(end string) {
+func (l *Lexer) skipComment(end string, mustEnd bool) {
 	for !l.eof() {
 		if l.slice(0, len(end)) == end {
 			l.skipN(len(end))
 			return
 		}
 		l.skip()
+	}
+	if mustEnd {
+		// TODO: improve error position
+		l.panicf("unclosed comment")
 	}
 }
 

--- a/pkg/parser/lexer.go
+++ b/pkg/parser/lexer.go
@@ -490,6 +490,9 @@ func (l *Lexer) skipN(n int) {
 }
 
 func (l *Lexer) slice(start, end int) string {
+	if len(l.Buffer) < l.pos+end {
+		end = len(l.Buffer) - l.pos
+	}
 	return string(l.Buffer[l.pos+start : l.pos+end])
 }
 

--- a/pkg/parser/lexer_test.go
+++ b/pkg/parser/lexer_test.go
@@ -137,6 +137,7 @@ var lexerWrongTestCase = []struct {
 	{"``", 0, "invalid empty identifier"},
 	{"1from", 1, "number literal cannot follow identifier without any spaces"},
 	{`'''0`, 0, "unclosed triple-quoted string literal"},
+	{`/*`, 2, "unclosed comment"},
 }
 
 func tokenEqual(t1, t2 *Token) bool {

--- a/pkg/parser/lexer_test.go
+++ b/pkg/parser/lexer_test.go
@@ -136,7 +136,7 @@ var lexerWrongTestCase = []struct {
 	{`"\UFFFFFFFF"`, 0, "invalid escape sequence: invalid code point: U+FFFFFFFF"},
 	{"``", 0, "invalid empty identifier"},
 	{"1from", 1, "number literal cannot follow identifier without any spaces"},
-	{`'''0`, 1, "unclosed triple-quoted string literal"},
+	{`'''0`, 0, "unclosed triple-quoted string literal"},
 }
 
 func tokenEqual(t1, t2 *Token) bool {

--- a/pkg/parser/lexer_test.go
+++ b/pkg/parser/lexer_test.go
@@ -136,6 +136,7 @@ var lexerWrongTestCase = []struct {
 	{`"\UFFFFFFFF"`, 0, "invalid escape sequence: invalid code point: U+FFFFFFFF"},
 	{"``", 0, "invalid empty identifier"},
 	{"1from", 1, "number literal cannot follow identifier without any spaces"},
+	{`'''0`, 1, "unclosed triple-quoted string literal"},
 }
 
 func tokenEqual(t1, t2 *Token) bool {


### PR DESCRIPTION
## Problem

The below SQL causes a panic.

```sql
SELECT """0
```

This PR fixes it.

NOTE: this bug is found  by using `go-fuzz` (#10).