### PR TITLE
Add support for foreign key to CREATE TABLE.

### DIFF
--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -1244,6 +1244,7 @@ type CreateTable struct {
 	Name        *Ident
 	Columns     []*ColumnDef
 	PrimaryKeys []*IndexKey
+	ForeignKeys []*ForeignKey
 	Cluster     *Cluster // optional
 }
 
@@ -1275,6 +1276,21 @@ type ColumnDefOptions struct {
 	Rparen  token.Pos // position of ")"
 
 	AllowCommitTimestamp bool
+}
+
+// ForeignKey is foreign key specifier in CREATE TABLE and ALTER TABLE.
+//
+//     {{if .Name}}CONSTRAINT {{.Name}}{{end}} FOREIGN KEY ({{.ColumnNames | sqlJoin ","}}) REFERENCES {{.ReferenceTable}}({{.ReferenceColumns | sqlJoin ","}})
+type ForeignKey struct {
+	// pos = Constraint || Foreign
+
+	Constraint token.Pos // position of "CONSTRAINT" keyword when Implicit is true
+	Foreign    token.Pos // position of "FOREIGN" keyword
+
+	Name             *Ident // optional
+	Columns          []*Ident
+	ReferenceTable   *Ident
+	ReferenceColumns []*Ident
 }
 
 // IndexKey is index key specifier in CREATE TABLE and CREATE INDEX.

--- a/pkg/ast/sql.go
+++ b/pkg/ast/sql.go
@@ -690,6 +690,9 @@ func (c *CreateTable) SQL() string {
 		}
 		sql += c.SQL()
 	}
+	for _, c := range c.ForeignKeys {
+		sql += ", " + c.SQL()
+	}
 	sql += ") "
 	sql += "PRIMARY KEY ("
 	for i, k := range c.PrimaryKeys {
@@ -713,6 +716,30 @@ func (c *ColumnDef) SQL() string {
 	if c.Options != nil {
 		sql += " " + c.Options.SQL()
 	}
+	return sql
+}
+
+func (c *ForeignKey) SQL() string {
+	var sql string
+	if c.Name != nil {
+		sql += "CONSTRAINT " + c.Name.SQL() + " "
+	}
+	sql += "FOREIGN KEY ("
+	for i, k := range c.Columns {
+		if i != 0 {
+			sql += ", "
+		}
+		sql += k.SQL()
+	}
+	sql += ") "
+	sql += "REFERENCES " + c.ReferenceTable.SQL() + " ("
+	for i, k := range c.ReferenceColumns {
+		if i != 0 {
+			sql += ", "
+		}
+		sql += k.SQL()
+	}
+	sql += ")"
 	return sql
 }
 

--- a/pkg/parser/testdata/input/ddl/create_table.sql
+++ b/pkg/parser/testdata/input/ddl/create_table.sql
@@ -1,5 +1,7 @@
 create table foo (
   foo int64,
   bar float64 not null,
-  baz string(255) not null options(allow_commit_timestamp = null)
+  baz string(255) not null options(allow_commit_timestamp = null),
+  foreign key (foo) references t2 (t2key1),
+  constraint fkname foreign key (foo, bar) references t2 (t2key1, t2key2)
 ) primary key (foo, bar)

--- a/pkg/parser/testdata/result/ddl/create_table.sql.txt
+++ b/pkg/parser/testdata/result/ddl/create_table.sql.txt
@@ -2,13 +2,15 @@
 create table foo (
   foo int64,
   bar float64 not null,
-  baz string(255) not null options(allow_commit_timestamp = null)
+  baz string(255) not null options(allow_commit_timestamp = null),
+  foreign key (foo) references t2 (t2key1),
+  constraint fkname foreign key (foo, bar) references t2 (t2key1, t2key2)
 ) primary key (foo, bar)
 
 --- AST
 &ast.CreateTable{
   Create: 0,
-  Rparen: 145,
+  Rparen: 264,
   Name:   &ast.Ident{
     NamePos: 13,
     NameEnd: 16,
@@ -74,8 +76,8 @@ create table foo (
     &ast.IndexKey{
       DirPos: -1,
       Name:   &ast.Ident{
-        NamePos: 137,
-        NameEnd: 140,
+        NamePos: 256,
+        NameEnd: 259,
         Name:    "foo",
       },
       Dir: "",
@@ -83,15 +85,79 @@ create table foo (
     &ast.IndexKey{
       DirPos: -1,
       Name:   &ast.Ident{
-        NamePos: 142,
-        NameEnd: 145,
+        NamePos: 261,
+        NameEnd: 264,
         Name:    "bar",
       },
       Dir: "",
+    },
+  },
+  ForeignKeys: []*ast.ForeignKey{
+    &ast.ForeignKey{
+      Constraint: 0,
+      Foreign:    125,
+      Name:       (*ast.Ident)(nil),
+      Columns:    []*ast.Ident{
+        &ast.Ident{
+          NamePos: 138,
+          NameEnd: 141,
+          Name:    "foo",
+        },
+      },
+      ReferenceTable: &ast.Ident{
+        NamePos: 154,
+        NameEnd: 156,
+        Name:    "t2",
+      },
+      ReferenceColumns: []*ast.Ident{
+        &ast.Ident{
+          NamePos: 158,
+          NameEnd: 164,
+          Name:    "t2key1",
+        },
+      },
+    },
+    &ast.ForeignKey{
+      Constraint: 169,
+      Foreign:    187,
+      Name:       &ast.Ident{
+        NamePos: 180,
+        NameEnd: 186,
+        Name:    "fkname",
+      },
+      Columns: []*ast.Ident{
+        &ast.Ident{
+          NamePos: 200,
+          NameEnd: 203,
+          Name:    "foo",
+        },
+        &ast.Ident{
+          NamePos: 205,
+          NameEnd: 208,
+          Name:    "bar",
+        },
+      },
+      ReferenceTable: &ast.Ident{
+        NamePos: 221,
+        NameEnd: 223,
+        Name:    "t2",
+      },
+      ReferenceColumns: []*ast.Ident{
+        &ast.Ident{
+          NamePos: 225,
+          NameEnd: 231,
+          Name:    "t2key1",
+        },
+        &ast.Ident{
+          NamePos: 233,
+          NameEnd: 239,
+          Name:    "t2key2",
+        },
+      },
     },
   },
   Cluster: (*ast.Cluster)(nil),
 }
 
 --- SQL
-CREATE TABLE foo (foo INT64, bar FLOAT64 NOT NULL, baz STRING(255) NOT NULL OPTIONS(allow_commit_timestamp = null)) PRIMARY KEY (foo, bar)
+CREATE TABLE foo (foo INT64, bar FLOAT64 NOT NULL, baz STRING(255) NOT NULL OPTIONS(allow_commit_timestamp = null), FOREIGN KEY (foo) REFERENCES t2 (t2key1), CONSTRAINT fkname FOREIGN KEY (foo, bar) REFERENCES t2 (t2key1, t2key2)) PRIMARY KEY (foo, bar)

--- a/pkg/parser/testdata/result/ddl/create_table_cluster.sql.txt
+++ b/pkg/parser/testdata/result/ddl/create_table_cluster.sql.txt
@@ -45,6 +45,7 @@ create table foo (
     },
   },
   PrimaryKeys: []*ast.IndexKey(nil),
+  ForeignKeys: []*ast.ForeignKey(nil),
   Cluster:     &ast.Cluster{
     Comma:       60,
     OnDeleteEnd: -1,

--- a/pkg/parser/testdata/result/ddl/create_table_cluster_on_delete_no_action.sql.txt
+++ b/pkg/parser/testdata/result/ddl/create_table_cluster_on_delete_no_action.sql.txt
@@ -40,7 +40,8 @@ create table foo (
       Dir: "",
     },
   },
-  Cluster: &ast.Cluster{
+  ForeignKeys: []*ast.ForeignKey(nil),
+  Cluster:     &ast.Cluster{
     Comma:       51,
     OnDeleteEnd: 115,
     TableName:   &ast.Ident{

--- a/pkg/parser/testdata/result/ddl/create_table_cluster_set_on_delete.sql.txt
+++ b/pkg/parser/testdata/result/ddl/create_table_cluster_set_on_delete.sql.txt
@@ -40,7 +40,8 @@ create table foo (
       Dir: "",
     },
   },
-  Cluster: &ast.Cluster{
+  ForeignKeys: []*ast.ForeignKey(nil),
+  Cluster:     &ast.Cluster{
     Comma:       50,
     OnDeleteEnd: 112,
     TableName:   &ast.Ident{

--- a/pkg/parser/testdata/result/ddl/create_table_trailing_comma.sql.txt
+++ b/pkg/parser/testdata/result/ddl/create_table_trailing_comma.sql.txt
@@ -66,7 +66,8 @@ create table foo (
       Dir: "DESC",
     },
   },
-  Cluster: (*ast.Cluster)(nil),
+  ForeignKeys: []*ast.ForeignKey(nil),
+  Cluster:     (*ast.Cluster)(nil),
 }
 
 --- SQL

--- a/pkg/parser/testdata/result/ddl/create_table_types.sql.txt
+++ b/pkg/parser/testdata/result/ddl/create_table_types.sql.txt
@@ -222,7 +222,8 @@ create table types (
       Dir: "",
     },
   },
-  Cluster: (*ast.Cluster)(nil),
+  ForeignKeys: []*ast.ForeignKey(nil),
+  Cluster:     (*ast.Cluster)(nil),
 }
 
 --- SQL

--- a/pkg/parser/testdata/result/statement/create_table.sql.txt
+++ b/pkg/parser/testdata/result/statement/create_table.sql.txt
@@ -2,13 +2,15 @@
 create table foo (
   foo int64,
   bar float64 not null,
-  baz string(255) not null options(allow_commit_timestamp = null)
+  baz string(255) not null options(allow_commit_timestamp = null),
+  foreign key (foo) references t2 (t2key1),
+  constraint fkname foreign key (foo, bar) references t2 (t2key1, t2key2)
 ) primary key (foo, bar)
 
 --- AST
 &ast.CreateTable{
   Create: 0,
-  Rparen: 145,
+  Rparen: 264,
   Name:   &ast.Ident{
     NamePos: 13,
     NameEnd: 16,
@@ -74,8 +76,8 @@ create table foo (
     &ast.IndexKey{
       DirPos: -1,
       Name:   &ast.Ident{
-        NamePos: 137,
-        NameEnd: 140,
+        NamePos: 256,
+        NameEnd: 259,
         Name:    "foo",
       },
       Dir: "",
@@ -83,15 +85,79 @@ create table foo (
     &ast.IndexKey{
       DirPos: -1,
       Name:   &ast.Ident{
-        NamePos: 142,
-        NameEnd: 145,
+        NamePos: 261,
+        NameEnd: 264,
         Name:    "bar",
       },
       Dir: "",
+    },
+  },
+  ForeignKeys: []*ast.ForeignKey{
+    &ast.ForeignKey{
+      Constraint: 0,
+      Foreign:    125,
+      Name:       (*ast.Ident)(nil),
+      Columns:    []*ast.Ident{
+        &ast.Ident{
+          NamePos: 138,
+          NameEnd: 141,
+          Name:    "foo",
+        },
+      },
+      ReferenceTable: &ast.Ident{
+        NamePos: 154,
+        NameEnd: 156,
+        Name:    "t2",
+      },
+      ReferenceColumns: []*ast.Ident{
+        &ast.Ident{
+          NamePos: 158,
+          NameEnd: 164,
+          Name:    "t2key1",
+        },
+      },
+    },
+    &ast.ForeignKey{
+      Constraint: 169,
+      Foreign:    187,
+      Name:       &ast.Ident{
+        NamePos: 180,
+        NameEnd: 186,
+        Name:    "fkname",
+      },
+      Columns: []*ast.Ident{
+        &ast.Ident{
+          NamePos: 200,
+          NameEnd: 203,
+          Name:    "foo",
+        },
+        &ast.Ident{
+          NamePos: 205,
+          NameEnd: 208,
+          Name:    "bar",
+        },
+      },
+      ReferenceTable: &ast.Ident{
+        NamePos: 221,
+        NameEnd: 223,
+        Name:    "t2",
+      },
+      ReferenceColumns: []*ast.Ident{
+        &ast.Ident{
+          NamePos: 225,
+          NameEnd: 231,
+          Name:    "t2key1",
+        },
+        &ast.Ident{
+          NamePos: 233,
+          NameEnd: 239,
+          Name:    "t2key2",
+        },
+      },
     },
   },
   Cluster: (*ast.Cluster)(nil),
 }
 
 --- SQL
-CREATE TABLE foo (foo INT64, bar FLOAT64 NOT NULL, baz STRING(255) NOT NULL OPTIONS(allow_commit_timestamp = null)) PRIMARY KEY (foo, bar)
+CREATE TABLE foo (foo INT64, bar FLOAT64 NOT NULL, baz STRING(255) NOT NULL OPTIONS(allow_commit_timestamp = null), FOREIGN KEY (foo) REFERENCES t2 (t2key1), CONSTRAINT fkname FOREIGN KEY (foo, bar) REFERENCES t2 (t2key1, t2key2)) PRIMARY KEY (foo, bar)

--- a/pkg/parser/testdata/result/statement/create_table_cluster.sql.txt
+++ b/pkg/parser/testdata/result/statement/create_table_cluster.sql.txt
@@ -45,6 +45,7 @@ create table foo (
     },
   },
   PrimaryKeys: []*ast.IndexKey(nil),
+  ForeignKeys: []*ast.ForeignKey(nil),
   Cluster:     &ast.Cluster{
     Comma:       60,
     OnDeleteEnd: -1,

--- a/pkg/parser/testdata/result/statement/create_table_cluster_on_delete_no_action.sql.txt
+++ b/pkg/parser/testdata/result/statement/create_table_cluster_on_delete_no_action.sql.txt
@@ -40,7 +40,8 @@ create table foo (
       Dir: "",
     },
   },
-  Cluster: &ast.Cluster{
+  ForeignKeys: []*ast.ForeignKey(nil),
+  Cluster:     &ast.Cluster{
     Comma:       51,
     OnDeleteEnd: 115,
     TableName:   &ast.Ident{

--- a/pkg/parser/testdata/result/statement/create_table_cluster_set_on_delete.sql.txt
+++ b/pkg/parser/testdata/result/statement/create_table_cluster_set_on_delete.sql.txt
@@ -40,7 +40,8 @@ create table foo (
       Dir: "",
     },
   },
-  Cluster: &ast.Cluster{
+  ForeignKeys: []*ast.ForeignKey(nil),
+  Cluster:     &ast.Cluster{
     Comma:       50,
     OnDeleteEnd: 112,
     TableName:   &ast.Ident{

--- a/pkg/parser/testdata/result/statement/create_table_trailing_comma.sql.txt
+++ b/pkg/parser/testdata/result/statement/create_table_trailing_comma.sql.txt
@@ -66,7 +66,8 @@ create table foo (
       Dir: "DESC",
     },
   },
-  Cluster: (*ast.Cluster)(nil),
+  ForeignKeys: []*ast.ForeignKey(nil),
+  Cluster:     (*ast.Cluster)(nil),
 }
 
 --- SQL

--- a/pkg/parser/testdata/result/statement/create_table_types.sql.txt
+++ b/pkg/parser/testdata/result/statement/create_table_types.sql.txt
@@ -222,7 +222,8 @@ create table types (
       Dir: "",
     },
   },
-  Cluster: (*ast.Cluster)(nil),
+  ForeignKeys: []*ast.ForeignKey(nil),
+  Cluster:     (*ast.Cluster)(nil),
 }
 
 --- SQL

--- a/pkg/parser/testdata/result/statement/select_expr.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_expr.sql.txt
@@ -25,7 +25,9 @@ select 1 + 2, 1 - 2,
        timestamp_add(timestamp "2019-09-01 08:11:22", interval 5 hour),
        1 in (1, 2, 3),
        2 in unnest([1, 2, 3]),
-       3 in (select 1 union all select 2 union all select 3)
+       3 in (select 1 union all select 2 union all select 3),
+       [1] || [2]
+
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
@@ -818,6 +820,39 @@ select 1 + 2, 1 - 2,
           },
         },
       },
+      &ast.ExprSelectItem{
+        Expr: &ast.BinaryExpr{
+          Op:   "||",
+          Left: &ast.ArrayLiteral{
+            Array:  0,
+            Lbrack: 754,
+            Rbrack: 756,
+            Type:   nil,
+            Values: []ast.Expr{
+              &ast.IntLiteral{
+                ValuePos: 755,
+                ValueEnd: 756,
+                Base:     10,
+                Value:    "1",
+              },
+            },
+          },
+          Right: &ast.ArrayLiteral{
+            Array:  0,
+            Lbrack: 761,
+            Rbrack: 763,
+            Type:   nil,
+            Values: []ast.Expr{
+              &ast.IntLiteral{
+                ValuePos: 762,
+                ValueEnd: 763,
+                Base:     10,
+                Value:    "2",
+              },
+            },
+          },
+        },
+      },
     },
     From:    (*ast.From)(nil),
     Where:   (*ast.Where)(nil),
@@ -829,4 +864,4 @@ select 1 + 2, 1 - 2,
 }
 
 --- SQL
-SELECT 1 + 2, 1 - 2, 1 * 2, 2 / 2, +1 + +1, -1 + -1, +1.2, -3.4, ~1 ^ ~1, 1 ^ 2, 2 & 1, 2 | 1, 1 << 2, 2 >> 1, foo.bar * +foo.bar * -foo.bar, (SELECT 1 AS `1`).`1`, NOT NOT TRUE, ARRAY[1, 2, 3][OFFSET(1)], ARRAY[1, 2, 3][OFFSET(1)], ARRAY[1, 2, 3][ORDINAL(1)], CASE WHEN 1 = 1 THEN "1 = 1" ELSE "else" END, CASE 1 WHEN 1 THEN "1" WHEN 2 THEN "2" ELSE "other" END, date_add(DATE "2019-09-01", INTERVAL 5 day), timestamp_add(TIMESTAMP "2019-09-01 08:11:22", INTERVAL 5 hour), 1 IN (1, 2, 3), 2 IN UNNEST(ARRAY[1, 2, 3]), 3 IN (SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3)
+SELECT 1 + 2, 1 - 2, 1 * 2, 2 / 2, +1 + +1, -1 + -1, +1.2, -3.4, ~1 ^ ~1, 1 ^ 2, 2 & 1, 2 | 1, 1 << 2, 2 >> 1, foo.bar * +foo.bar * -foo.bar, (SELECT 1 AS `1`).`1`, NOT NOT TRUE, ARRAY[1, 2, 3][OFFSET(1)], ARRAY[1, 2, 3][OFFSET(1)], ARRAY[1, 2, 3][ORDINAL(1)], CASE WHEN 1 = 1 THEN "1 = 1" ELSE "else" END, CASE 1 WHEN 1 THEN "1" WHEN 2 THEN "2" ELSE "other" END, date_add(DATE "2019-09-01", INTERVAL 5 day), timestamp_add(TIMESTAMP "2019-09-01 08:11:22", INTERVAL 5 hour), 1 IN (1, 2, 3), 2 IN UNNEST(ARRAY[1, 2, 3]), 3 IN (SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3), ARRAY[1] || ARRAY[2]


### PR DESCRIPTION
Hi, I'm using your awesome library through `handy-spanner`.

Recently, `Cloud Spanner` supported the Foreign key feature and I'd like to use it on `handy-spanner`. This PR adds support FKs like below to `CREATE TABLE` in `memefish`. Could you take a look at this PR?

```sql
FOREIGN KEY (k1) REFERENCES T2 (t2key1)
CONSTRAINT foreignkey_name FOREIGN KEY (k1, k2) REFERENCES t2 (t2key1, t2key2)
```

ref: 
- [外部キー  \|  Cloud Spanner  \|  Google Cloud](https://cloud.google.com/spanner/docs/foreign-keys/overview)
- [外部キー関係の作成と管理  \|  Cloud Spanner  \|  Google Cloud](https://cloud.google.com/spanner/docs/foreign-keys/how-to)