### PR TITLE
modify ParseDDL to return nil if query has only comment.(has no idents)

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -1886,6 +1886,8 @@ func (p *Parser) lookaheadType() bool {
 func (p *Parser) parseDDL() ast.DDL {
 	pos := p.Token.Pos
 	switch {
+	case p.Token.Kind == token.TokenEOF:
+		return nil
 	case p.Token.Kind == "CREATE":
 		p.nextToken()
 		switch {

--- a/tools/parse/main.go
+++ b/tools/parse/main.go
@@ -55,9 +55,11 @@ func main() {
 
 	fmt.Println("--- AST")
 	_, _ = pp.Println(node)
-	fmt.Println()
-	fmt.Println("--- SQL")
-	fmt.Println(node.SQL())
+	if node != nil {
+		fmt.Println()
+		fmt.Println("--- SQL")
+		fmt.Println(node.SQL())
+	}
 }
 
 func logf(msg string, params ...interface{}) {


### PR DESCRIPTION
Hi!

I use https://github.com/cloudspannerecosystem/yo , and yo use memefish.

I want parse DDL such as 
```
go run ./tools/parse -mode=ddl "# hoge"
2021/06/21 22:37:04 syntax error::1:7: expected token: CREATE, <ident>, but: <eof>

  1:  # hoge
            ^
exit status 1
```

And I changed `parseDDL` to return nil if first token kind is `token.TokenEOF` .
Please review this change.

Thanks!