### PR TITLE
fix(parser): adjust `AND` and `OR` precedence

### DIFF
--- a/pkg/ast/sql.go
+++ b/pkg/ast/sql.go
@@ -18,7 +18,8 @@ const (
 	precBitOr
 	precComparison
 	precNot
-	precAndOr
+	precAnd
+	precOr
 )
 
 func exprPrec(e Expr) prec {
@@ -45,8 +46,10 @@ func exprPrec(e Expr) prec {
 			return precBitOr
 		case OpEqual, OpNotEqual, OpLess, OpLessEqual, OpGreater, OpGreaterEqual, OpLike, OpNotLike:
 			return precComparison
-		case OpAnd, OpOr:
-			return precAndOr
+		case OpAnd:
+			return precAnd
+		case OpOr:
+			return precOr
 		}
 	case *UnaryExpr:
 		switch e.Op {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -915,18 +915,35 @@ func (p *Parser) parseTableSampleSize() *ast.TableSampleSize {
 // ================================================================================
 
 func (p *Parser) parseExpr() ast.Expr {
-	return p.parseAndOr()
+	return p.parseOr()
 }
 
-func (p *Parser) parseAndOr() ast.Expr {
+func (p *Parser) parseOr() ast.Expr {
+	expr := p.parseAnd()
+	for {
+		var op ast.BinaryOp
+		switch p.Token.Kind {
+		case "OR":
+			op = ast.OpOr
+		default:
+			return expr
+		}
+		p.nextToken()
+		expr = &ast.BinaryExpr{
+			Left:  expr,
+			Op:    op,
+			Right: p.parseAnd(),
+		}
+	}
+}
+
+func (p *Parser) parseAnd() ast.Expr {
 	expr := p.parseNot()
 	for {
 		var op ast.BinaryOp
 		switch p.Token.Kind {
 		case "AND":
 			op = ast.OpAnd
-		case "OR":
-			op = ast.OpOr
 		default:
 			return expr
 		}

--- a/pkg/parser/testdata/result/query/select_singer_with_where_and_op.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_where_and_op.sql.txt
@@ -34,24 +34,24 @@ WHERE
     Where: &ast.Where{
       Where: 26,
       Expr:  &ast.BinaryExpr{
-        Op:   "AND",
+        Op:   "OR",
         Left: &ast.BinaryExpr{
-          Op:   "OR",
-          Left: &ast.BinaryExpr{
-            Op:   "=",
-            Left: &ast.Ident{
-              NamePos: 34,
-              NameEnd: 42,
-              Name:    "SingerID",
-            },
-            Right: &ast.IntLiteral{
-              ValuePos: 45,
-              ValueEnd: 46,
-              Base:     10,
-              Value:    "1",
-            },
+          Op:   "=",
+          Left: &ast.Ident{
+            NamePos: 34,
+            NameEnd: 42,
+            Name:    "SingerID",
           },
-          Right: &ast.BinaryExpr{
+          Right: &ast.IntLiteral{
+            ValuePos: 45,
+            ValueEnd: 46,
+            Base:     10,
+            Value:    "1",
+          },
+        },
+        Right: &ast.BinaryExpr{
+          Op:   "AND",
+          Left: &ast.BinaryExpr{
             Op:   "=",
             Left: &ast.Ident{
               NamePos: 50,
@@ -64,18 +64,18 @@ WHERE
               Value:    "foobar",
             },
           },
-        },
-        Right: &ast.BinaryExpr{
-          Op:   "=",
-          Left: &ast.Ident{
-            NamePos: 75,
-            NameEnd: 83,
-            Name:    "LastName",
-          },
-          Right: &ast.StringLiteral{
-            ValuePos: 86,
-            ValueEnd: 96,
-            Value:    "fizzbuzz",
+          Right: &ast.BinaryExpr{
+            Op:   "=",
+            Left: &ast.Ident{
+              NamePos: 75,
+              NameEnd: 83,
+              Name:    "LastName",
+            },
+            Right: &ast.StringLiteral{
+              ValuePos: 86,
+              ValueEnd: 96,
+              Value:    "fizzbuzz",
+            },
           },
         },
       },

--- a/pkg/parser/testdata/result/statement/select_singer_with_where_and_op.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_where_and_op.sql.txt
@@ -34,24 +34,24 @@ WHERE
     Where: &ast.Where{
       Where: 26,
       Expr:  &ast.BinaryExpr{
-        Op:   "AND",
+        Op:   "OR",
         Left: &ast.BinaryExpr{
-          Op:   "OR",
-          Left: &ast.BinaryExpr{
-            Op:   "=",
-            Left: &ast.Ident{
-              NamePos: 34,
-              NameEnd: 42,
-              Name:    "SingerID",
-            },
-            Right: &ast.IntLiteral{
-              ValuePos: 45,
-              ValueEnd: 46,
-              Base:     10,
-              Value:    "1",
-            },
+          Op:   "=",
+          Left: &ast.Ident{
+            NamePos: 34,
+            NameEnd: 42,
+            Name:    "SingerID",
           },
-          Right: &ast.BinaryExpr{
+          Right: &ast.IntLiteral{
+            ValuePos: 45,
+            ValueEnd: 46,
+            Base:     10,
+            Value:    "1",
+          },
+        },
+        Right: &ast.BinaryExpr{
+          Op:   "AND",
+          Left: &ast.BinaryExpr{
             Op:   "=",
             Left: &ast.Ident{
               NamePos: 50,
@@ -64,18 +64,18 @@ WHERE
               Value:    "foobar",
             },
           },
-        },
-        Right: &ast.BinaryExpr{
-          Op:   "=",
-          Left: &ast.Ident{
-            NamePos: 75,
-            NameEnd: 83,
-            Name:    "LastName",
-          },
-          Right: &ast.StringLiteral{
-            ValuePos: 86,
-            ValueEnd: 96,
-            Value:    "fizzbuzz",
+          Right: &ast.BinaryExpr{
+            Op:   "=",
+            Left: &ast.Ident{
+              NamePos: 75,
+              NameEnd: 83,
+              Name:    "LastName",
+            },
+            Right: &ast.StringLiteral{
+              ValuePos: 86,
+              ValueEnd: 96,
+              Value:    "fizzbuzz",
+            },
           },
         },
       },


### PR DESCRIPTION
Following returns true in spanner query.

```
SELECT TRUE OR FALSE AND FALSE
```

But current AST returns following

```go
       Expr: &ast.BinaryExpr{
          Op:   "AND",
          Left: &ast.BinaryExpr{
            Op:   "OR",
            Left: &ast.BoolLiteral{
              ValuePos: 7,
              Value:    true,
            },
            Right: &ast.BoolLiteral{
              ValuePos: 15,
              Value:    false,
            },
          },
          Right: &ast.BoolLiteral{
            ValuePos: 25,
            Value:    false,
          },
        },
      },
```

Which will evaluate to `false`, which is not correct I think and spec says AND has higher precedence.

https://cloud.google.com/spanner/docs/reference/standard-sql/operators

Order of Precedence | Operator | Input Data Types | Name | Operator Arity
-- | -- | -- | -- | --
11 | AND | BOOL | Logical AND | Binary
12 | OR | BOOL | Logical OR | Binary

