### PR TITLE
Support the WITH Common Table Expression syntax in parser

### DIFF
--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -239,7 +239,8 @@ type QueryStatement struct {
 	// pos = (Hint ?? Expr).pos
 	// end = Expr.end
 
-	Hint  *Hint // optional
+	Hint  *Hint                   // optional
+	CTEs  []CommonTableExpression // optional
 	Query QueryExpr
 }
 
@@ -324,6 +325,15 @@ type SubQuery struct {
 	Query   QueryExpr
 	OrderBy *OrderBy // optional
 	Limit   *Limit   // optional
+}
+
+// CommonTableExpression is CTE statement node
+//
+// cte_name AS ( query_expr )
+type CommonTableExpression struct {
+	Pos   token.Pos // position of cte_name
+	Name  string
+	Query QueryExpr
 }
 
 // Star is a single * in SELECT result columns list.

--- a/pkg/ast/sql.go
+++ b/pkg/ast/sql.go
@@ -80,6 +80,17 @@ func (q *QueryStatement) SQL() string {
 	if q.Hint != nil {
 		sql += q.Hint.SQL() + " "
 	}
+	if q.CTEs != nil {
+		sql += "WITH "
+		for i, cte := range q.CTEs {
+			sql += cte.Name + " AS (" + cte.Query.SQL() + ")"
+			if i != len(q.CTEs)-1 {
+				sql += ","
+			} else {
+				sql += " "
+			}
+		}
+	}
 	sql += q.Query.SQL()
 	return sql
 }

--- a/pkg/parser/testdata/input/query/select_with_ctes.sql
+++ b/pkg/parser/testdata/input/query/select_with_ctes.sql
@@ -1,0 +1,1 @@
+@{hint1 = 1, hint2 = 2} select hint

--- a/pkg/parser/testdata/input/query/select_with_ctes.sql
+++ b/pkg/parser/testdata/input/query/select_with_ctes.sql
@@ -1,1 +1,4 @@
-@{hint1 = 1, hint2 = 2} select hint
+WITH
+    subQ1 AS (SELECT * FROM Roster WHERE SchoolID = 52),
+    subQ2 AS (SELECT SchoolID FROM subQ1)
+SELECT DISTINCT * FROM subQ2

--- a/pkg/parser/testdata/result/query/select_album_with_index_directive.sql.txt
+++ b/pkg/parser/testdata/result/query/select_album_with_index_directive.sql.txt
@@ -6,6 +6,7 @@ WHERE AlbumTitle >= @startTitle AND AlbumTitle < @endTitle
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_alias_without_as.sql.txt
+++ b/pkg/parser/testdata/result/query/select_alias_without_as.sql.txt
@@ -4,6 +4,7 @@ select 1 A
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_array_with_struct.sql.txt
+++ b/pkg/parser/testdata/result/query/select_array_with_struct.sql.txt
@@ -7,6 +7,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_cast.sql.txt
+++ b/pkg/parser/testdata/result/query/select_cast.sql.txt
@@ -8,6 +8,7 @@ limit cast(1 as INT64) offset cast(@foo as INT64)
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_complex_with_array_path.sql.txt
+++ b/pkg/parser/testdata/result/query/select_complex_with_array_path.sql.txt
@@ -8,6 +8,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_complex_with_unnest_array_path.sql.txt
+++ b/pkg/parser/testdata/result/query/select_complex_with_unnest_array_path.sql.txt
@@ -8,6 +8,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_count_asterisk.sql.txt
+++ b/pkg/parser/testdata/result/query/select_count_asterisk.sql.txt
@@ -4,6 +4,7 @@ select count(*) from singers
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_count_distinct.sql.txt
+++ b/pkg/parser/testdata/result/query/select_count_distinct.sql.txt
@@ -3,6 +3,7 @@ select count(distinct x) from foo
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_expr.sql.txt
+++ b/pkg/parser/testdata/result/query/select_expr.sql.txt
@@ -31,6 +31,7 @@ select 1 + 2, 1 - 2,
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_expr_extract.sql.txt
+++ b/pkg/parser/testdata/result/query/select_expr_extract.sql.txt
@@ -22,6 +22,7 @@ select
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_hint.sql.txt
+++ b/pkg/parser/testdata/result/query/select_hint.sql.txt
@@ -34,6 +34,7 @@
       },
     },
   },
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   24,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_literals_all.sql.txt
+++ b/pkg/parser/testdata/result/query/select_literals_all.sql.txt
@@ -47,6 +47,7 @@ lines''',
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_literals_array.sql.txt
+++ b/pkg/parser/testdata/result/query/select_literals_array.sql.txt
@@ -9,6 +9,7 @@ SELECT
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_literals_array_invalid.sql.txt
+++ b/pkg/parser/testdata/result/query/select_literals_array_invalid.sql.txt
@@ -5,6 +5,7 @@ SELECT
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_literals_bytes.sql.txt
+++ b/pkg/parser/testdata/result/query/select_literals_bytes.sql.txt
@@ -14,6 +14,7 @@ SELECT
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_literals_date.sql.txt
+++ b/pkg/parser/testdata/result/query/select_literals_date.sql.txt
@@ -14,6 +14,7 @@ SELECT
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_literals_float.sql.txt
+++ b/pkg/parser/testdata/result/query/select_literals_float.sql.txt
@@ -8,6 +8,7 @@ SELECT
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_literals_int.sql.txt
+++ b/pkg/parser/testdata/result/query/select_literals_int.sql.txt
@@ -8,6 +8,7 @@ SELECT
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_literals_paren.sql.txt
+++ b/pkg/parser/testdata/result/query/select_literals_paren.sql.txt
@@ -4,6 +4,7 @@ SELECT (1)
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_literals_paren_with_operator.sql.txt
+++ b/pkg/parser/testdata/result/query/select_literals_paren_with_operator.sql.txt
@@ -4,6 +4,7 @@ SELECT (1+1)
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_literals_string.sql.txt
+++ b/pkg/parser/testdata/result/query/select_literals_string.sql.txt
@@ -26,6 +26,7 @@ lines''',
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_literals_struct.sql.txt
+++ b/pkg/parser/testdata/result/query/select_literals_struct.sql.txt
@@ -12,6 +12,7 @@ SELECT
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_nest_complex.sql.txt
+++ b/pkg/parser/testdata/result/query/select_nest_complex.sql.txt
@@ -9,6 +9,7 @@ from (
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_select_limit_expr.sql.txt
+++ b/pkg/parser/testdata/result/query/select_select_limit_expr.sql.txt
@@ -4,6 +4,7 @@ select ((select 1) limit 1 offset 0) + 3
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_select_set_operator_expr.sql.txt
+++ b/pkg/parser/testdata/result/query/select_select_set_operator_expr.sql.txt
@@ -6,6 +6,7 @@ select ((select 1) union all (select 2)) + 3,
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_singer_with_as_struct_subquery.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_as_struct_subquery.sql.txt
@@ -11,6 +11,7 @@ SELECT
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_singer_with_asterisk.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_asterisk.sql.txt
@@ -7,6 +7,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_singer_with_column_and_asterisk.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_column_and_asterisk.sql.txt
@@ -8,6 +8,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_singer_with_column_names.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_column_names.sql.txt
@@ -10,6 +10,7 @@ FROM Singers
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_singer_with_cross_join.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_cross_join.sql.txt
@@ -9,6 +9,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_singer_with_distinct.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_distinct.sql.txt
@@ -8,6 +8,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: true,

--- a/pkg/parser/testdata/result/query/select_singer_with_full_join.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_full_join.sql.txt
@@ -8,6 +8,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_singer_with_groupby.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_groupby.sql.txt
@@ -9,6 +9,7 @@ GROUP BY
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_singer_with_hash_join.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_hash_join.sql.txt
@@ -16,6 +16,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_singer_with_having.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_having.sql.txt
@@ -11,6 +11,7 @@ HAVING
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_singer_with_in_and_unnest.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_in_and_unnest.sql.txt
@@ -9,6 +9,7 @@ WHERE
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_singer_with_in_and_unnest_with_query_parameter.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_in_and_unnest_with_query_parameter.sql.txt
@@ -9,6 +9,7 @@ WHERE
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_singer_with_join.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_join.sql.txt
@@ -10,6 +10,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_singer_with_join_hint.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_join_hint.sql.txt
@@ -19,6 +19,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_singer_with_join_twice.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_join_twice.sql.txt
@@ -13,6 +13,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_singer_with_join_using.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_join_using.sql.txt
@@ -10,6 +10,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_singer_with_join_various.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_join_various.sql.txt
@@ -33,6 +33,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_singer_with_limit.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_limit.sql.txt
@@ -8,6 +8,7 @@ LIMIT 100
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_singer_with_limit_and_skiprows.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_limit_and_skiprows.sql.txt
@@ -9,6 +9,7 @@ OFFSET 10
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_singer_with_orderby.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_orderby.sql.txt
@@ -10,6 +10,7 @@ ORDER BY
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_singer_with_query_parameter.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_query_parameter.sql.txt
@@ -10,6 +10,7 @@ WHERE
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_singer_with_root_parent.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_root_parent.sql.txt
@@ -4,6 +4,7 @@
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.SubQuery{
     Lparen: 0,
     Rparen: 24,

--- a/pkg/parser/testdata/result/query/select_singer_with_select_in_from.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_select_in_from.sql.txt
@@ -13,6 +13,7 @@ FROM (
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_singer_with_select_in_from_and_as.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_select_in_from_and_as.sql.txt
@@ -13,6 +13,7 @@ FROM (
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_singer_with_single_column_subquery.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_single_column_subquery.sql.txt
@@ -7,6 +7,7 @@ SELECT (
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_singer_with_single_column_subquery_with_at.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_single_column_subquery_with_at.sql.txt
@@ -7,6 +7,7 @@ SELECT (
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_singer_with_table_alias.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_table_alias.sql.txt
@@ -8,6 +8,7 @@ FROM Singers S
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_singer_with_table_alias_with_hint.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_table_alias_with_hint.sql.txt
@@ -7,6 +7,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_singer_with_table_hint.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_table_hint.sql.txt
@@ -7,6 +7,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_singer_with_tablesample.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_tablesample.sql.txt
@@ -9,6 +9,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_singer_with_tableset.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_tableset.sql.txt
@@ -6,6 +6,7 @@ SELECT * FROM Singers
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.CompoundQuery{
     Op:       "UNION",
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_singer_with_tableset_complex.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_tableset_complex.sql.txt
@@ -26,6 +26,7 @@ UNION ALL
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.CompoundQuery{
     Op:       "UNION",
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_singer_with_tableset_with_where.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_tableset_with_where.sql.txt
@@ -10,6 +10,7 @@ ORDER BY
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.CompoundQuery{
     Op:       "UNION",
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_singer_with_toplevel_join_hint.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_toplevel_join_hint.sql.txt
@@ -27,6 +27,7 @@ FROM
       },
     },
   },
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   25,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_singer_with_value_hex.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_value_hex.sql.txt
@@ -9,6 +9,7 @@ WHERE
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_singer_with_where.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_where.sql.txt
@@ -9,6 +9,7 @@ WHERE
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_singer_with_where_and_comparison.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_where_and_comparison.sql.txt
@@ -26,6 +26,7 @@ WHERE
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_singer_with_where_and_op.sql.txt
+++ b/pkg/parser/testdata/result/query/select_singer_with_where_and_op.sql.txt
@@ -9,6 +9,7 @@ WHERE
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_struct_compare_eq.sql.txt
+++ b/pkg/parser/testdata/result/query/select_struct_compare_eq.sql.txt
@@ -10,6 +10,7 @@ SELECT ARRAY(
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_tablesample_with_cross_join.sql.txt
+++ b/pkg/parser/testdata/result/query/select_tablesample_with_cross_join.sql.txt
@@ -10,6 +10,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_tablesample_with_subquery.sql.txt
+++ b/pkg/parser/testdata/result/query/select_tablesample_with_subquery.sql.txt
@@ -7,6 +7,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_tablesample_with_table.sql.txt
+++ b/pkg/parser/testdata/result/query/select_tablesample_with_table.sql.txt
@@ -7,6 +7,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_tablesample_with_table_alias.sql.txt
+++ b/pkg/parser/testdata/result/query/select_tablesample_with_table_alias.sql.txt
@@ -7,6 +7,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_tablesample_with_unnest_invalid.sql.txt
+++ b/pkg/parser/testdata/result/query/select_tablesample_with_unnest_invalid.sql.txt
@@ -7,6 +7,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_union_chain.sql.txt
+++ b/pkg/parser/testdata/result/query/select_union_chain.sql.txt
@@ -4,6 +4,7 @@
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.CompoundQuery{
     Op:       "UNION",
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_unnest_with_offset.sql.txt
+++ b/pkg/parser/testdata/result/query/select_unnest_with_offset.sql.txt
@@ -7,6 +7,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_unnest_with_offset_and_alias.sql.txt
+++ b/pkg/parser/testdata/result/query/select_unnest_with_offset_and_alias.sql.txt
@@ -7,6 +7,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_unnest_with_offset_and_alias_min.sql.txt
+++ b/pkg/parser/testdata/result/query/select_unnest_with_offset_and_alias_min.sql.txt
@@ -7,6 +7,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_with_comment.sql.txt
+++ b/pkg/parser/testdata/result/query/select_with_comment.sql.txt
@@ -5,6 +5,7 @@ select 1
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   10,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_with_ctes.sql.txt
+++ b/pkg/parser/testdata/result/query/select_with_ctes.sql.txt
@@ -1,0 +1,126 @@
+--- select_with_ctes.sql
+WITH
+    subQ1 AS (SELECT * FROM Roster WHERE SchoolID = 52),
+    subQ2 AS (SELECT SchoolID FROM subQ1)
+SELECT DISTINCT * FROM subQ2
+--- AST
+&ast.QueryStatement{
+  Hint: (*ast.Hint)(nil),
+  CTEs: []ast.CommonTableExpression{
+    ast.CommonTableExpression{
+      Pos:   0,
+      Name:  "subQ1",
+      Query: &ast.Select{
+        Select:   19,
+        Distinct: false,
+        AsStruct: false,
+        Results:  []ast.SelectItem{
+          &ast.Star{
+            Star: 26,
+          },
+        },
+        From: &ast.From{
+          From:   28,
+          Source: &ast.TableName{
+            Table: &ast.Ident{
+              NamePos: 33,
+              NameEnd: 39,
+              Name:    "Roster",
+            },
+            Hint:   (*ast.Hint)(nil),
+            As:     (*ast.AsAlias)(nil),
+            Sample: (*ast.TableSample)(nil),
+          },
+        },
+        Where: &ast.Where{
+          Where: 40,
+          Expr:  &ast.BinaryExpr{
+            Op:   "=",
+            Left: &ast.Ident{
+              NamePos: 46,
+              NameEnd: 54,
+              Name:    "SchoolID",
+            },
+            Right: &ast.IntLiteral{
+              ValuePos: 57,
+              ValueEnd: 59,
+              Base:     10,
+              Value:    "52",
+            },
+          },
+        },
+        GroupBy: (*ast.GroupBy)(nil),
+        Having:  (*ast.Having)(nil),
+        OrderBy: (*ast.OrderBy)(nil),
+        Limit:   (*ast.Limit)(nil),
+      },
+    },
+    ast.CommonTableExpression{
+      Pos:   0,
+      Name:  "subQ2",
+      Query: &ast.Select{
+        Select:   76,
+        Distinct: false,
+        AsStruct: false,
+        Results:  []ast.SelectItem{
+          &ast.ExprSelectItem{
+            Expr: &ast.Ident{
+              NamePos: 83,
+              NameEnd: 91,
+              Name:    "SchoolID",
+            },
+          },
+        },
+        From: &ast.From{
+          From:   92,
+          Source: &ast.TableName{
+            Table: &ast.Ident{
+              NamePos: 97,
+              NameEnd: 102,
+              Name:    "subQ1",
+            },
+            Hint:   (*ast.Hint)(nil),
+            As:     (*ast.AsAlias)(nil),
+            Sample: (*ast.TableSample)(nil),
+          },
+        },
+        Where:   (*ast.Where)(nil),
+        GroupBy: (*ast.GroupBy)(nil),
+        Having:  (*ast.Having)(nil),
+        OrderBy: (*ast.OrderBy)(nil),
+        Limit:   (*ast.Limit)(nil),
+      },
+    },
+  },
+  Query: &ast.Select{
+    Select:   104,
+    Distinct: true,
+    AsStruct: false,
+    Results:  []ast.SelectItem{
+      &ast.Star{
+        Star: 120,
+      },
+    },
+    From: &ast.From{
+      From:   122,
+      Source: &ast.TableName{
+        Table: &ast.Ident{
+          NamePos: 127,
+          NameEnd: 132,
+          Name:    "subQ2",
+        },
+        Hint:   (*ast.Hint)(nil),
+        As:     (*ast.AsAlias)(nil),
+        Sample: (*ast.TableSample)(nil),
+      },
+    },
+    Where:   (*ast.Where)(nil),
+    GroupBy: (*ast.GroupBy)(nil),
+    Having:  (*ast.Having)(nil),
+    OrderBy: (*ast.OrderBy)(nil),
+    Limit:   (*ast.Limit)(nil),
+  },
+}
+
+--- SQL
+WITH subQ1 AS (SELECT * FROM Roster WHERE SchoolID = 52),subQ2 AS (SELECT SchoolID FROM subQ1) SELECT DISTINCT * FROM subQ2

--- a/pkg/parser/testdata/result/query/select_with_field_path.sql.txt
+++ b/pkg/parser/testdata/result/query/select_with_field_path.sql.txt
@@ -20,6 +20,7 @@ WHERE A.z.a = 2
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_with_reservedword.sql.txt
+++ b/pkg/parser/testdata/result/query/select_with_reservedword.sql.txt
@@ -7,6 +7,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/query/select_with_trailing_comma.sql.txt
+++ b/pkg/parser/testdata/result/query/select_with_trailing_comma.sql.txt
@@ -3,6 +3,7 @@ SELECT 1, 2,
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_album_with_index_directive.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_album_with_index_directive.sql.txt
@@ -6,6 +6,7 @@ WHERE AlbumTitle >= @startTitle AND AlbumTitle < @endTitle
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_alias_without_as.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_alias_without_as.sql.txt
@@ -4,6 +4,7 @@ select 1 A
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_array_with_struct.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_array_with_struct.sql.txt
@@ -7,6 +7,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_cast.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_cast.sql.txt
@@ -8,6 +8,7 @@ limit cast(1 as INT64) offset cast(@foo as INT64)
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_complex_with_array_path.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_complex_with_array_path.sql.txt
@@ -8,6 +8,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_complex_with_unnest_array_path.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_complex_with_unnest_array_path.sql.txt
@@ -8,6 +8,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_count_asterisk.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_count_asterisk.sql.txt
@@ -4,6 +4,7 @@ select count(*) from singers
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_count_distinct.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_count_distinct.sql.txt
@@ -3,6 +3,7 @@ select count(distinct x) from foo
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_expr.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_expr.sql.txt
@@ -31,6 +31,7 @@ select 1 + 2, 1 - 2,
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_expr_extract.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_expr_extract.sql.txt
@@ -22,6 +22,7 @@ select
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_hint.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_hint.sql.txt
@@ -34,6 +34,7 @@
       },
     },
   },
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   24,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_literals_all.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_literals_all.sql.txt
@@ -47,6 +47,7 @@ lines''',
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_literals_array.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_literals_array.sql.txt
@@ -9,6 +9,7 @@ SELECT
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_literals_array_invalid.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_literals_array_invalid.sql.txt
@@ -5,6 +5,7 @@ SELECT
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_literals_bytes.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_literals_bytes.sql.txt
@@ -14,6 +14,7 @@ SELECT
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_literals_date.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_literals_date.sql.txt
@@ -14,6 +14,7 @@ SELECT
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_literals_float.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_literals_float.sql.txt
@@ -8,6 +8,7 @@ SELECT
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_literals_int.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_literals_int.sql.txt
@@ -8,6 +8,7 @@ SELECT
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_literals_paren.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_literals_paren.sql.txt
@@ -4,6 +4,7 @@ SELECT (1)
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_literals_paren_with_operator.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_literals_paren_with_operator.sql.txt
@@ -4,6 +4,7 @@ SELECT (1+1)
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_literals_string.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_literals_string.sql.txt
@@ -26,6 +26,7 @@ lines''',
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_literals_struct.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_literals_struct.sql.txt
@@ -12,6 +12,7 @@ SELECT
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_nest_complex.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_nest_complex.sql.txt
@@ -9,6 +9,7 @@ from (
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_select_limit_expr.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_select_limit_expr.sql.txt
@@ -4,6 +4,7 @@ select ((select 1) limit 1 offset 0) + 3
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_select_set_operator_expr.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_select_set_operator_expr.sql.txt
@@ -6,6 +6,7 @@ select ((select 1) union all (select 2)) + 3,
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_singer_with_as_struct_subquery.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_as_struct_subquery.sql.txt
@@ -11,6 +11,7 @@ SELECT
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_singer_with_asterisk.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_asterisk.sql.txt
@@ -7,6 +7,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_singer_with_column_and_asterisk.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_column_and_asterisk.sql.txt
@@ -8,6 +8,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_singer_with_column_names.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_column_names.sql.txt
@@ -10,6 +10,7 @@ FROM Singers
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_singer_with_cross_join.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_cross_join.sql.txt
@@ -9,6 +9,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_singer_with_distinct.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_distinct.sql.txt
@@ -8,6 +8,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: true,

--- a/pkg/parser/testdata/result/statement/select_singer_with_full_join.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_full_join.sql.txt
@@ -8,6 +8,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_singer_with_groupby.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_groupby.sql.txt
@@ -9,6 +9,7 @@ GROUP BY
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_singer_with_hash_join.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_hash_join.sql.txt
@@ -16,6 +16,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_singer_with_having.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_having.sql.txt
@@ -11,6 +11,7 @@ HAVING
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_singer_with_in_and_unnest.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_in_and_unnest.sql.txt
@@ -9,6 +9,7 @@ WHERE
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_singer_with_in_and_unnest_with_query_parameter.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_in_and_unnest_with_query_parameter.sql.txt
@@ -9,6 +9,7 @@ WHERE
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_singer_with_join.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_join.sql.txt
@@ -10,6 +10,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_singer_with_join_hint.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_join_hint.sql.txt
@@ -19,6 +19,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_singer_with_join_twice.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_join_twice.sql.txt
@@ -13,6 +13,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_singer_with_join_using.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_join_using.sql.txt
@@ -10,6 +10,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_singer_with_join_various.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_join_various.sql.txt
@@ -33,6 +33,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_singer_with_limit.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_limit.sql.txt
@@ -8,6 +8,7 @@ LIMIT 100
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_singer_with_limit_and_skiprows.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_limit_and_skiprows.sql.txt
@@ -9,6 +9,7 @@ OFFSET 10
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_singer_with_orderby.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_orderby.sql.txt
@@ -10,6 +10,7 @@ ORDER BY
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_singer_with_query_parameter.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_query_parameter.sql.txt
@@ -10,6 +10,7 @@ WHERE
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_singer_with_root_parent.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_root_parent.sql.txt
@@ -4,6 +4,7 @@
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.SubQuery{
     Lparen: 0,
     Rparen: 24,

--- a/pkg/parser/testdata/result/statement/select_singer_with_select_in_from.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_select_in_from.sql.txt
@@ -13,6 +13,7 @@ FROM (
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_singer_with_select_in_from_and_as.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_select_in_from_and_as.sql.txt
@@ -13,6 +13,7 @@ FROM (
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_singer_with_single_column_subquery.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_single_column_subquery.sql.txt
@@ -7,6 +7,7 @@ SELECT (
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_singer_with_single_column_subquery_with_at.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_single_column_subquery_with_at.sql.txt
@@ -7,6 +7,7 @@ SELECT (
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_singer_with_table_alias.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_table_alias.sql.txt
@@ -8,6 +8,7 @@ FROM Singers S
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_singer_with_table_alias_with_hint.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_table_alias_with_hint.sql.txt
@@ -7,6 +7,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_singer_with_table_hint.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_table_hint.sql.txt
@@ -7,6 +7,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_singer_with_tablesample.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_tablesample.sql.txt
@@ -9,6 +9,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_singer_with_tableset.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_tableset.sql.txt
@@ -6,6 +6,7 @@ SELECT * FROM Singers
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.CompoundQuery{
     Op:       "UNION",
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_singer_with_tableset_complex.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_tableset_complex.sql.txt
@@ -26,6 +26,7 @@ UNION ALL
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.CompoundQuery{
     Op:       "UNION",
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_singer_with_tableset_with_where.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_tableset_with_where.sql.txt
@@ -10,6 +10,7 @@ ORDER BY
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.CompoundQuery{
     Op:       "UNION",
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_singer_with_toplevel_join_hint.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_toplevel_join_hint.sql.txt
@@ -27,6 +27,7 @@ FROM
       },
     },
   },
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   25,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_singer_with_value_hex.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_value_hex.sql.txt
@@ -9,6 +9,7 @@ WHERE
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_singer_with_where.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_where.sql.txt
@@ -9,6 +9,7 @@ WHERE
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_singer_with_where_and_comparison.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_where_and_comparison.sql.txt
@@ -26,6 +26,7 @@ WHERE
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_singer_with_where_and_op.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_singer_with_where_and_op.sql.txt
@@ -9,6 +9,7 @@ WHERE
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_struct_compare_eq.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_struct_compare_eq.sql.txt
@@ -10,6 +10,7 @@ SELECT ARRAY(
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_tablesample_with_cross_join.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_tablesample_with_cross_join.sql.txt
@@ -10,6 +10,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_tablesample_with_subquery.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_tablesample_with_subquery.sql.txt
@@ -7,6 +7,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_tablesample_with_table.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_tablesample_with_table.sql.txt
@@ -7,6 +7,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_tablesample_with_table_alias.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_tablesample_with_table_alias.sql.txt
@@ -7,6 +7,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_tablesample_with_unnest_invalid.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_tablesample_with_unnest_invalid.sql.txt
@@ -7,6 +7,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_union_chain.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_union_chain.sql.txt
@@ -4,6 +4,7 @@
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.CompoundQuery{
     Op:       "UNION",
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_unnest_with_offset.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_unnest_with_offset.sql.txt
@@ -7,6 +7,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_unnest_with_offset_and_alias.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_unnest_with_offset_and_alias.sql.txt
@@ -7,6 +7,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_unnest_with_offset_and_alias_min.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_unnest_with_offset_and_alias_min.sql.txt
@@ -7,6 +7,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_with_comment.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_with_comment.sql.txt
@@ -5,6 +5,7 @@ select 1
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   10,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_with_ctes.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_with_ctes.sql.txt
@@ -1,0 +1,126 @@
+--- select_with_ctes.sql
+WITH
+    subQ1 AS (SELECT * FROM Roster WHERE SchoolID = 52),
+    subQ2 AS (SELECT SchoolID FROM subQ1)
+SELECT DISTINCT * FROM subQ2
+--- AST
+&ast.QueryStatement{
+  Hint: (*ast.Hint)(nil),
+  CTEs: []ast.CommonTableExpression{
+    ast.CommonTableExpression{
+      Pos:   0,
+      Name:  "subQ1",
+      Query: &ast.Select{
+        Select:   19,
+        Distinct: false,
+        AsStruct: false,
+        Results:  []ast.SelectItem{
+          &ast.Star{
+            Star: 26,
+          },
+        },
+        From: &ast.From{
+          From:   28,
+          Source: &ast.TableName{
+            Table: &ast.Ident{
+              NamePos: 33,
+              NameEnd: 39,
+              Name:    "Roster",
+            },
+            Hint:   (*ast.Hint)(nil),
+            As:     (*ast.AsAlias)(nil),
+            Sample: (*ast.TableSample)(nil),
+          },
+        },
+        Where: &ast.Where{
+          Where: 40,
+          Expr:  &ast.BinaryExpr{
+            Op:   "=",
+            Left: &ast.Ident{
+              NamePos: 46,
+              NameEnd: 54,
+              Name:    "SchoolID",
+            },
+            Right: &ast.IntLiteral{
+              ValuePos: 57,
+              ValueEnd: 59,
+              Base:     10,
+              Value:    "52",
+            },
+          },
+        },
+        GroupBy: (*ast.GroupBy)(nil),
+        Having:  (*ast.Having)(nil),
+        OrderBy: (*ast.OrderBy)(nil),
+        Limit:   (*ast.Limit)(nil),
+      },
+    },
+    ast.CommonTableExpression{
+      Pos:   0,
+      Name:  "subQ2",
+      Query: &ast.Select{
+        Select:   76,
+        Distinct: false,
+        AsStruct: false,
+        Results:  []ast.SelectItem{
+          &ast.ExprSelectItem{
+            Expr: &ast.Ident{
+              NamePos: 83,
+              NameEnd: 91,
+              Name:    "SchoolID",
+            },
+          },
+        },
+        From: &ast.From{
+          From:   92,
+          Source: &ast.TableName{
+            Table: &ast.Ident{
+              NamePos: 97,
+              NameEnd: 102,
+              Name:    "subQ1",
+            },
+            Hint:   (*ast.Hint)(nil),
+            As:     (*ast.AsAlias)(nil),
+            Sample: (*ast.TableSample)(nil),
+          },
+        },
+        Where:   (*ast.Where)(nil),
+        GroupBy: (*ast.GroupBy)(nil),
+        Having:  (*ast.Having)(nil),
+        OrderBy: (*ast.OrderBy)(nil),
+        Limit:   (*ast.Limit)(nil),
+      },
+    },
+  },
+  Query: &ast.Select{
+    Select:   104,
+    Distinct: true,
+    AsStruct: false,
+    Results:  []ast.SelectItem{
+      &ast.Star{
+        Star: 120,
+      },
+    },
+    From: &ast.From{
+      From:   122,
+      Source: &ast.TableName{
+        Table: &ast.Ident{
+          NamePos: 127,
+          NameEnd: 132,
+          Name:    "subQ2",
+        },
+        Hint:   (*ast.Hint)(nil),
+        As:     (*ast.AsAlias)(nil),
+        Sample: (*ast.TableSample)(nil),
+      },
+    },
+    Where:   (*ast.Where)(nil),
+    GroupBy: (*ast.GroupBy)(nil),
+    Having:  (*ast.Having)(nil),
+    OrderBy: (*ast.OrderBy)(nil),
+    Limit:   (*ast.Limit)(nil),
+  },
+}
+
+--- SQL
+WITH subQ1 AS (SELECT * FROM Roster WHERE SchoolID = 52),subQ2 AS (SELECT SchoolID FROM subQ1) SELECT DISTINCT * FROM subQ2

--- a/pkg/parser/testdata/result/statement/select_with_field_path.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_with_field_path.sql.txt
@@ -20,6 +20,7 @@ WHERE A.z.a = 2
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_with_reservedword.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_with_reservedword.sql.txt
@@ -7,6 +7,7 @@ FROM
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,

--- a/pkg/parser/testdata/result/statement/select_with_trailing_comma.sql.txt
+++ b/pkg/parser/testdata/result/statement/select_with_trailing_comma.sql.txt
@@ -3,6 +3,7 @@ SELECT 1, 2,
 --- AST
 &ast.QueryStatement{
   Hint:  (*ast.Hint)(nil),
+  CTEs:  []ast.CommonTableExpression(nil),
   Query: &ast.Select{
     Select:   0,
     Distinct: false,


### PR DESCRIPTION
Spanner SQL supported WITH CTEs syntax now: https://cloud.google.com/spanner/docs/reference/standard-sql/query-syntax